### PR TITLE
Update downloads badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 HTMLArk
 =======
 
-.. image:: https://img.shields.io/github/downloads/BitLooter/htmlark/total.svg
-        :target: https://github.com/BitLooter/htmlark
+.. image:: https://pepy.tech/badge/htmlark
+        :target: https://pepy.tech/project/htmlark
 .. image:: https://img.shields.io/pypi/v/HTMLArk.svg
         :target: https://pypi.python.org/pypi/HTMLArk
 .. image:: https://img.shields.io/pypi/l/HTMLArk.svg


### PR DESCRIPTION
Thanks for the great plugin!

The downloads badge (set at 90) doesn't do your package justice, you're already at 19k downloads.

Hope you'll consider continuing support & development, I'd like to depend on & recommend your plugin for https://github.com/timvink/mkdocs-print-site-plugin